### PR TITLE
Broadened the scope to any input, not just text and password types

### DIFF
--- a/jquery.infieldLabel.js
+++ b/jquery.infieldLabel.js
@@ -30,7 +30,7 @@
 
 		// first time input setup
 		base.setup = function() {
-			base.$input = base.$el.find("input[type=text],input[type=password]");
+			base.$input = base.$el.find("input");
 			base.$label = base.$el.find("label");
 
 			// hide label if there's already a value


### PR DESCRIPTION
Instead of narrowing the scope to just text and password input types, allow the script to find any input type (e.g., email, date, number, url).
