### PR TITLE
Fix: infield placeholder no longer blocks focus event

### DIFF
--- a/jquery.infieldLabel.js
+++ b/jquery.infieldLabel.js
@@ -49,8 +49,10 @@
 				});
 
 				base.$label.on('click.infield', function() {
-					// empty onclick to fix older ios devices
-					// http://stackoverflow.com/a/6472181/222155
+					base.$el
+						.removeClass(base.options.hideClass)
+						.addClass(base.options.focusClass);
+					base.$input.focus()
 				});
 		};
 


### PR DESCRIPTION
The infield label is absolutely positioned over the element, this blocks the click event going to the input making it impossible to focus. Clicking on the overlaid label now focuses the input.
